### PR TITLE
Checkout submodules in EDK2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ mkdir edk2-test-build
 cd edk2-test-build
 repo init -u https://github.com/glikely/edk2-test-manifest
 repo sync
+(cd edk2; git submodule update --init)
 ./buildzip.sh AARCH64
 ```
 


### PR DESCRIPTION
Without checking out the submodules in edk2, buildzip.sh will cause build error and stopped.